### PR TITLE
Allow access token to be registered with credentials

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -12,12 +12,17 @@ var _access_token;
 var _credentials = {};
 
 function _register_credentials (credentials) {
-	_.each(required_credentials, function (credentialName) {
-		if (!_.has(credentials, credentialName)) {
-			console.log(credentials);
-			throw new Error('You must specify "' + credentialName + '" within your credentials');
-		}
-	});
+	if (credentials.access_token) {
+		_access_token = credentials.access_token;
+	} else {
+		_.each(required_credentials, function (credentialName) {
+			if (!_.has(credentials, credentialName)) {
+				console.log(credentials);
+				throw new Error('When not providing access_token, you must specify "'
+					+ credentialName + '" within your credentials');
+			}
+		});
+	}
 	_credentials = credentials;
 }
 


### PR DESCRIPTION
Allows `access_token` to be passed in as a credential, as an alternative to `username`,`password`,`client_id`, and `client_secret`.

Useful when you already have an access token, and don't need to obtain a new one.
