### PR TITLE
fix string literal "null" being appended to list queries 

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 
 function processArgs (args) {
 	var params = {
-		id: null,
+		id: '',
 		options: null,
 		callback: function() { }
 	};


### PR DESCRIPTION
When you dont specifiy an id for a resource and do a get, null gets appended to the url (e.g. `https://myinstall.axosoft.com/api/v5/releasesnull`)
