### PR TITLE
Make both base_url and credentials required in api.register

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -32,6 +32,13 @@ function _register_base_url (base_url) {
 }
 
 function register (base_url, credentials) {
+	if (!base_url) {
+		throw new Error('The parameter "base_url" is required.');
+	}
+	if (!credentials) {
+		throw new Error('The parameter "credentials" is required.');
+	}
+
 	_register_base_url(base_url);
 	_register_credentials(credentials);
 }


### PR DESCRIPTION
If you omitted base_url everything would still work until you tried to actually make a call. I added an explicit requirement for it so that the user knows right away it won't work.

Omitting credentials would already fail due to trying to access `credentials.access_token` but I added a check for that as well so it has a clearer error message that's consistent with the base_url error.